### PR TITLE
Fix styling in the debugger when #wantsAnnotationPane preference is on

### DIFF
--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/buildCodePaneWith..st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/buildCodePaneWith..st
@@ -3,12 +3,10 @@ buildCodePaneWith: aBuilder
 	
 	| spec textSpec |
 	spec := super buildCodePaneWith: aBuilder.
-	(spec respondsTo: #stylerClass:)
-		ifTrue: [textSpec := spec]
-		ifFalse: [
-			"This seems brittle but it is kind of stable as it relies on the basic
-			structure of the browser"
-			textSpec := spec children last].
+	textSpec := (spec respondsTo: #stylerClass:)
+		ifTrue: [spec]
+		ifFalse: [spec children detect: [:child | (child respondsTo: #stylerClass:)
+			and: [child getText = #contents]]].
 	textSpec stylerClass: BPStyler.
 	
 	textSpec name: #codePaneTextMorph.

--- a/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
@@ -8,7 +8,7 @@
 	"instance" : {
 		"aboutToStyle:" : "jb 12/3/2020 23:32",
 		"aboutToStyle:requestor:" : "jb 12/3/2020 23:32",
-		"buildCodePaneWith:" : "pre 1/21/2021 18:42",
+		"buildCodePaneWith:" : "ct 6/19/2021 21:47",
 		"buildDefaultBrowserWith:" : "pre 1/6/2021 10:50",
 		"classIconAt:" : "pre 2/15/2021 11:50",
 		"defaultBrowserTitle" : "pre 11/8/2019 17:17",

--- a/packages/Babylonian-UI.package/BPDebugger.class/instance/buildCodePaneWith..st
+++ b/packages/Babylonian-UI.package/BPDebugger.class/instance/buildCodePaneWith..st
@@ -3,12 +3,10 @@ buildCodePaneWith: aBuilder
 	
 	| spec textSpec |
 	spec := super buildCodePaneWith: aBuilder.
-	(spec respondsTo: #stylerClass:)
-		ifTrue: [textSpec := spec]
-		ifFalse: [
-			"This seems brittle but it is kind of stable as it relies on the basic
-			structure of the browser"
-			textSpec := spec children last].
+	textSpec := (spec respondsTo: #stylerClass:)
+		ifTrue: [spec]
+		ifFalse: [spec children detect: [:child | (child respondsTo: #stylerClass:)
+			and: [child getText = #contents]]].
 	textSpec stylerClass: BPStyler.
 	
 	textSpec name: #codePaneTextMorph.

--- a/packages/Babylonian-UI.package/BPDebugger.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPDebugger.class/methodProperties.json
@@ -3,4 +3,4 @@
 		 },
 	"instance" : {
 		"aboutToStyle:" : "pre 1/21/2021 18:46",
-		"buildCodePaneWith:" : "pre 1/21/2021 18:43" } }
+		"buildCodePaneWith:" : "ct 6/19/2021 21:46" } }


### PR DESCRIPTION
Also apply the same change to BPBrowser to make it more robust.

This is how the Babylonian debugger looked before this patch:

![image](https://user-images.githubusercontent.com/38782922/122742424-37e2e780-d286-11eb-9b03-a0e2119464a9.png)
