### PR TITLE
Fix rendering of embedded objects in `CompositionScanner`

### DIFF
--- a/packages/Babylonian-UI.package/CompositionScanner.extension/instance/placeEmbeddedObjectsFrom..st
+++ b/packages/Babylonian-UI.package/CompositionScanner.extension/instance/placeEmbeddedObjectsFrom..st
@@ -1,8 +1,10 @@
 *Babylonian-UI
 placeEmbeddedObjectsFrom: textAttributes
+	
 	textAttributes size > 1 
 		ifTrue: ["We fake the layouting by creating an intermediate morph"
 			lineHeight := font height + (textAttributes collect: [:attribute | attribute anchoredMorph height]) sum.
+			line stop: lastIndex.
 			^ true]
 		ifFalse: ["This is the base system case"
 			^ super placeEmbeddedObjectsFrom: textAttributes]

--- a/packages/Babylonian-UI.package/CompositionScanner.extension/methodProperties.json
+++ b/packages/Babylonian-UI.package/CompositionScanner.extension/methodProperties.json
@@ -2,4 +2,4 @@
 	"class" : {
 		 },
 	"instance" : {
-		"placeEmbeddedObjectsFrom:" : "pre 1/27/2020 16:41" } }
+		"placeEmbeddedObjectsFrom:" : "ct 6/20/2021 01:23" } }


### PR DESCRIPTION
In the past, doing certain™ things in the babylonian browser frequently crashed it to crash for me with awkward rendering errors. Skimming through the existing stop conditions on the composition scanner revealed that all of them set lastIndex in the TextLine iff they return true (and thus break the loop in `#composeFrom:inRectangle:firstLine:leftSide:rightSide:`). With this change, my special example does not break the rendering engine any longer:

```smalltalk
foo: aNumber with: anotherNumber
	<exampleNamed: 'some example 5' self: 'TestObject new' with: '2' with: '8'>
	| tmp |
	tmp := aNumber * anotherNumber.
	^ "<bpProbe id: 4248111>""<bpReplace for: 'all examples' with: []>"tmp"</bpReplace>""</bpProbe>" sqrt
```

This is how it looked before:

![image](https://user-images.githubusercontent.com/38782922/122743800-a2485780-d287-11eb-80b4-58365703b7ad.png)

![image](https://user-images.githubusercontent.com/38782922/122743886-bdb36280-d287-11eb-97dc-32fa9052aeba.png)
