### PR TITLE
:balloon: recategorize party :balloon:

### DIFF
--- a/packages/Babylonian-Compiler.package/BPCompiler.class/class/bpInstrumentedLayerName.st
+++ b/packages/Babylonian-Compiler.package/BPCompiler.class/class/bpInstrumentedLayerName.st
@@ -1,4 +1,4 @@
-nil
+accessing
 bpInstrumentedLayerName
 
 	^ #bpInstrumented

--- a/packages/Babylonian-Compiler.package/ClassDescription.extension/instance/addAndClassifySelector.withMethod.inProtocol.notifying..st
+++ b/packages/Babylonian-Compiler.package/ClassDescription.extension/instance/addAndClassifySelector.withMethod.inProtocol.notifying..st
@@ -1,4 +1,4 @@
-*Babylonian-Compiler
+*Babylonian-Compiler-*contexts2-core-accessing method dictionary-override-override
 addAndClassifySelector: selector withMethod: compiledMethod inProtocol: category notifying: requestor
 	
 	"This is an abomination of the Squeak Kernel code, ContextS2 code, and Babylonian Code"

--- a/packages/Babylonian-Compiler.package/Scanner.extension/class/initializeTypeTable.st
+++ b/packages/Babylonian-Compiler.package/Scanner.extension/class/initializeTypeTable.st
@@ -1,4 +1,4 @@
-*Babylonian-Compiler
+*Babylonian-Compiler-initialization-override
 initializeTypeTable
 	
 	"self initializeTypeTable"

--- a/packages/Babylonian-UI.package/Character.extension/instance/isSeparator.st
+++ b/packages/Babylonian-UI.package/Character.extension/instance/isSeparator.st
@@ -1,4 +1,4 @@
-*Babylonian-UI
+*Babylonian-UI-testing-override
 isSeparator
 	"Answer whether the receiver is one of the separator characters--space, 
 	cr, tab, line feed, or form feed."

--- a/packages/Babylonian-UI.package/MessageSet.extension/instance/aboutToStyle..st
+++ b/packages/Babylonian-UI.package/MessageSet.extension/instance/aboutToStyle..st
@@ -1,4 +1,4 @@
-*Babylonian-UI
+*Babylonian-UI-code pane-override
 aboutToStyle: aPluggableShoutMorphOrView
 	"This is a notification that aPluggableShoutMorphOrView is about to re-style its text.
 	Set the classOrMetaClass in aPluggableShoutMorphOrView, so that identifiers

--- a/packages/Babylonian-UI.package/TextMorph.extension/instance/enterClickableRegion..st
+++ b/packages/Babylonian-UI.package/TextMorph.extension/instance/enterClickableRegion..st
@@ -1,4 +1,4 @@
-*Babylonian-UI
+*Babylonian-UI-editing-override
 enterClickableRegion: evt
 	| index isLink |
 	evt hand hasSubmorphs ifTrue:[^false].


### PR DESCRIPTION
add `-override` suffix to extension methods that shadow existing methods from the base system, so that Monticello does not fall over them (e.g., if babylonian should be ever unloaded, for instance during a squot operation)