### PR TITLE
Fix "probe it" shortcut for non-`CodeHolder` models such as workspaces

### DIFF
--- a/packages/Babylonian-UI.package/SmalltalkEditor.extension/instance/probeSelection.st
+++ b/packages/Babylonian-UI.package/SmalltalkEditor.extension/instance/probeSelection.st
@@ -1,4 +1,5 @@
 *Babylonian-UI
 probeSelection
-
-	model addProbeToSelection
+	 
+	(model respondsTo: #addProbeToSelection)
+		ifTrue: [model addProbeToSelection]

--- a/packages/Babylonian-UI.package/SmalltalkEditor.extension/methodProperties.json
+++ b/packages/Babylonian-UI.package/SmalltalkEditor.extension/methodProperties.json
@@ -3,4 +3,4 @@
 		 },
 	"instance" : {
 		"probeIt:" : "pre 7/13/2020 15:32",
-		"probeSelection" : "pre 7/13/2020 15:32" } }
+		"probeSelection" : "ct 8/28/2021 15:55" } }


### PR DESCRIPTION
In the past, you got a DNU, now, nothing happens instead.