### PR TITLE
Enables drag and drop of annotated methods in Babylonian Browser

### DIFF
--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/dropOnMessageCategories.at..st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/dropOnMessageCategories.at..st
@@ -1,0 +1,16 @@
+drag and drop
+dropOnMessageCategories: aMethodReference at: anIndex
+	
+	"As we work with CSMethodObjects instead of CompiledMethods diretly, this is the same 
+	as CSBrowser handles drag and drop"
+	| targetClass targetCategory |
+	aMethodReference isContextSMethod ifTrue: [
+		targetClass := self selectedClassOrMetaClass.
+		(targetClass == aMethodReference methodClass)
+			ifTrue: [
+				targetCategory := self messageCategoryList at: anIndex.
+				targetCategory = ClassOrganizer allCategory ifTrue: [^ false].
+				targetClass organization classify: aMethodReference asSymbol under: targetCategory.
+				^ true]
+			ifFalse: [^ self inform: 'Can only move partial methods within a class']].
+	^ super dropOnMessageCategories: aMethodReference at: anIndex

--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/wantsMessageCategoriesDrop..st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/wantsMessageCategoriesDrop..st
@@ -1,0 +1,4 @@
+drag and drop
+wantsMessageCategoriesDrop: anObject
+
+	^ (super wantsMessageCategoriesDrop: anObject) or: [anObject isContextSMethod]

--- a/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
@@ -12,8 +12,10 @@
 		"buildDefaultBrowserWith:" : "pre 1/6/2021 10:50",
 		"classIconAt:" : "ct 8/18/2021 17:32",
 		"defaultBrowserTitle" : "pre 11/8/2019 17:17",
+		"dropOnMessageCategories:at:" : "jb 8/29/2021 23:13",
 		"exampleIconForClass:" : "ct 8/18/2021 17:33",
 		"exampleIconForSelector:" : "ct 8/18/2021 17:27",
 		"messageIconFor:" : "ct 8/18/2021 17:28",
 		"messageList" : "pre 9/24/2020 14:26",
-		"rawMessageCategoryList" : "jb 12/3/2020 22:54" } }
+		"rawMessageCategoryList" : "jb 12/3/2020 22:54",
+		"wantsMessageCategoriesDrop:" : "jb 8/29/2021 22:15" } }


### PR DESCRIPTION
Drag and drop was previously only functioning for methods without annotations, since they are `CompiledMethod`s instead of `CSLayeredMethod`s. The `BPBrowser`, as a subclass of `Browser`, handled drag and drop only for `CompiledMethod`. Seeing as the `CSBrowser` supports drag and drop for `CSLayeredMethod`s, the `BPBrowser` has been added support for `CSLayeredMethod` the same as `CSBrowser` does