### PR TITLE
Adds an unannotated view to the BPBrowser

### DIFF
--- a/packages/Babylonian-Tests.package/BPSearchCollection.class/class/compilerClass.st
+++ b/packages/Babylonian-Tests.package/BPSearchCollection.class/class/compilerClass.st
@@ -1,4 +1,4 @@
-as yet unclassified
+compiling
 compilerClass
 
 	^ BPCompiler

--- a/packages/Babylonian-Tests.package/BPSearchCollection.class/methodProperties.json
+++ b/packages/Babylonian-Tests.package/BPSearchCollection.class/methodProperties.json
@@ -1,6 +1,6 @@
 {
 	"class" : {
-		"compilerClass" : "pre 11/9/2019 15:00",
+		"compilerClass" : "jb 10/30/2021 00:30",
 		"numbersUpTo10" : "pre 11/9/2019 15:06",
 		"numbersUpTo10000" : "pre 10/22/2020 13:54" },
 	"instance" : {

--- a/packages/Babylonian-UI.package/BPBrowser.class/class/defaultContentsSymbolQuints.st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/class/defaultContentsSymbolQuints.st
@@ -1,0 +1,10 @@
+controls
+defaultContentsSymbolQuints
+	
+	^ {super defaultContentsSymbolQuints first},
+		{{#unannotated
+				. #toggleUnannotatedSource 
+				. #showingUnannotatedSourceString
+				. 'unannotated'
+				. 'the textual source without Babylonian annotations'}},
+		super defaultContentsSymbolQuints allButFirst

--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/selectedMessage.st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/selectedMessage.st
@@ -1,0 +1,25 @@
+message list
+selectedMessage
+
+	"Has to be copied from CodeHolder and get injected to check for unannotated source 
+	before moving on to showingDocumentation"
+
+	| class selector method |
+	contents == nil ifFalse: [^ contents copy].
+
+	self showingDecompile ifTrue:
+		[^ self decompiledSourceIntoContents].
+
+	class := self selectedClassOrMetaClass.
+	selector := self selectedMessageName.
+	method := class compiledMethodAt: selector ifAbsent: [^ ''].	"method deleted while in another project"
+	currentCompiledMethod := method.
+	
+	"=== BABYLONIAN CODE START ==="
+	self showingUnannotated ifTrue: [^ self sourceStringUnannotated].
+	"=== BABYLONIAN CODE END    ==="
+
+	^ contents := (self showingDocumentation
+		ifFalse: [ self sourceStringPrettifiedAndDiffed ]
+		ifTrue: [ self commentContents ])
+			copy asText makeSelectorBoldIn: class

--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/showUnannotated..st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/showUnannotated..st
@@ -1,0 +1,4 @@
+what to show
+showUnannotated: aBoolean
+
+	self contentsSymbol: (aBoolean ifFalse: [#source] ifTrue: [#unannotated])

--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/showingUnannotated.st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/showingUnannotated.st
@@ -1,0 +1,4 @@
+what to show
+showingUnannotated
+
+	^ self contentsSymbol == #unannotated

--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/showingUnannotatedSourceString.st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/showingUnannotatedSourceString.st
@@ -1,0 +1,8 @@
+what to show
+showingUnannotatedSourceString
+
+	^ (self showingUnannotated
+		ifTrue:
+			['<yes>']
+		ifFalse:
+			['<no>']), 'unannotated'

--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/sourceStringUnannotated.st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/sourceStringUnannotated.st
@@ -11,7 +11,7 @@ sourceStringUnannotated
 	sourceString := class ultimateSourceCodeAt: selector ifAbsent: [^'error'].
 	self validateMessageSource: sourceString forSelector: selector inClass: class.
 	sourceString := BPUnannotatedStyler new 
-		selectedMethod: class>>selector;
+		selectedMethod: (MethodReference  class: class selector: selector);
+		classOrMetaClass: class;
 		styledTextFor: sourceString.
-	
 	^ sourceString

--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/sourceStringUnannotated.st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/sourceStringUnannotated.st
@@ -1,0 +1,17 @@
+message list
+sourceStringUnannotated
+
+	"Adapt super to deal with actual methods, hence duplicated code"
+	"Answer a copy of the source code for the selected message, transformed by diffing and pretty-printing exigencies"
+
+	| class selector sourceString |
+	class := self selectedClassOrMetaClass.
+	selector := self selectedMessageName.
+	(class isNil or: [selector isNil]) ifTrue: [^'missing'].
+	sourceString := class ultimateSourceCodeAt: selector ifAbsent: [^'error'].
+	self validateMessageSource: sourceString forSelector: selector inClass: class.
+	sourceString := BPUnannotatedStyler new 
+		selectedMethod: class>>selector;
+		styledTextFor: sourceString.
+	
+	^ sourceString

--- a/packages/Babylonian-UI.package/BPBrowser.class/instance/toggleUnannotatedSource.st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/instance/toggleUnannotatedSource.st
@@ -1,0 +1,10 @@
+what to show
+toggleUnannotatedSource
+
+	| wasShowing |
+	self okToChange ifTrue:
+		[wasShowing := self showingUnannotated.
+		self restoreTextualCodingPane.
+		self showUnannotated: wasShowing not.
+		self setContentsToForceRefetch.
+		self contentsChanged].

--- a/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
@@ -3,6 +3,7 @@
 		"automaticallyAcceptMethodOnAddingAnnotations" : "pre 6/7/2021 14:34",
 		"automaticallyAcceptMethodOnAddingAnnotations:" : "pre 6/7/2021 14:35",
 		"compilerClass" : "pre 7/26/2019 10:07",
+		"defaultContentsSymbolQuints" : "jb 10/30/2021 17:40",
 		"initialize" : "pre 8/25/2020 10:35",
 		"startUp" : "jb 12/3/2020 23:07" },
 	"instance" : {
@@ -21,5 +22,11 @@
 		"messageList" : "pre 9/24/2020 14:26",
 		"openExampleInstanceInHand:" : "pre 9/28/2021 16:25",
 		"rawMessageCategoryList" : "jb 12/3/2020 22:54",
+		"selectedMessage" : "jb 10/30/2021 13:52",
+		"showUnannotated:" : "jb 10/29/2021 23:07",
+		"showingUnannotated" : "jb 10/29/2021 22:58",
+		"showingUnannotatedSourceString" : "jb 11/1/2021 00:58",
+		"sourceStringUnannotated" : "jb 11/2/2021 15:03",
+		"toggleUnannotatedSource" : "jb 10/29/2021 23:15",
 		"toolBuilderModelsMenu:" : "pre 9/28/2021 16:32",
 		"wantsMessageCategoriesDrop:" : "jb 8/29/2021 22:15" } }

--- a/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
@@ -26,7 +26,7 @@
 		"showUnannotated:" : "jb 10/29/2021 23:07",
 		"showingUnannotated" : "jb 10/29/2021 22:58",
 		"showingUnannotatedSourceString" : "jb 11/1/2021 00:58",
-		"sourceStringUnannotated" : "jb 11/2/2021 15:03",
+		"sourceStringUnannotated" : "jb 11/10/2021 23:53",
 		"toggleUnannotatedSource" : "jb 10/29/2021 23:15",
 		"toolBuilderModelsMenu:" : "pre 9/28/2021 16:32",
 		"wantsMessageCategoriesDrop:" : "jb 8/29/2021 22:15" } }

--- a/packages/Babylonian-UI.package/BPStyler.class/instance/insertAnchorCharacterForAnnotation.from.at..st
+++ b/packages/Babylonian-UI.package/BPStyler.class/instance/insertAnchorCharacterForAnnotation.from.at..st
@@ -1,0 +1,16 @@
+private
+insertAnchorCharacterForAnnotation: annotation from: aText at: startTagStart
+
+	|  startOfExpressionText expressionText |
+	
+	startOfExpressionText := aText indexOfSubCollection: annotation enclosedExpressionSource startingAt: startTagStart.
+	expressionText := aText copyFrom: startOfExpressionText to: startOfExpressionText + annotation enclosedExpressionSource size - 1.
+	(self isAlreadyAnnotatedExpressionAt: startTagStart in: aText) 
+		ifTrue: [
+			expressionText := (aText copyFrom: startTagStart - 1 to: startTagStart - 1) , expressionText]
+		ifFalse: [
+			expressionText := Character startOfHeader asString asText , expressionText.
+			expressionText attributesAt: 2 do: [:attr | 
+				expressionText addAttribute: attr from: 1 to: 1]].
+		
+	^ expressionText

--- a/packages/Babylonian-UI.package/BPStyler.class/instance/textForAnnotation.from.at..st
+++ b/packages/Babylonian-UI.package/BPStyler.class/instance/textForAnnotation.from.at..st
@@ -1,22 +1,14 @@
 private
 textForAnnotation: annotation from: aText at: startTagStart
-	
-	| newMorph startOfExpressionText expressionText |
+
+	| newMorph expressionText |
 	newMorph := self annotationMorphFor: annotation.	
 	
 	newMorph ifNil: [
 		"The annotation does not want to be drawn directly"
 		^ '' asText].
 	
-	startOfExpressionText := aText indexOfSubCollection: annotation enclosedExpressionSource startingAt: startTagStart.
-	expressionText := aText copyFrom: startOfExpressionText to: startOfExpressionText + annotation enclosedExpressionSource size - 1.
-	(self isAlreadyAnnotatedExpressionAt: startTagStart in: aText) 
-		ifTrue: [
-			expressionText := (aText copyFrom: startTagStart - 1 to: startTagStart - 1) , expressionText]
-		ifFalse: [
-			expressionText := Character startOfHeader asString asText , expressionText.
-			expressionText attributesAt: 2 do: [:attr | 
-				expressionText addAttribute: attr from: 1 to: 1]].
+	expressionText := self insertAnchorCharacterForAnnotation: annotation from: aText at: startTagStart.
 	expressionText addAttribute: (BPTextAnchor new anchoredMorph: newMorph; yourself).
 	
 	^ expressionText

--- a/packages/Babylonian-UI.package/BPStyler.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPStyler.class/methodProperties.json
@@ -14,6 +14,7 @@
 		"extractIntervals" : "jb 12/3/2020 22:57",
 		"hasExamplesMorph:" : "jb 8/21/2021 15:38",
 		"ifNoSelectedMethod:" : "pre 3/19/2020 11:07",
+		"insertAnchorCharacterForAnnotation:from:at:" : "jb 11/10/2021 23:27",
 		"insertExamplesMorph:into:withNewLineStartingFrom:to:" : "jb 8/21/2021 16:29",
 		"insertExamplesMorphFrom:into:basedOn:" : "jb 8/21/2021 16:31",
 		"isAlreadyAnnotatedExpressionAt:in:" : "pre 5/29/2019 22:40",
@@ -22,5 +23,5 @@
 		"reformat:basedOn:" : "jb 12/3/2020 22:58",
 		"removePotentialEmptyLinesInText:around:" : "pre 8/25/2020 09:47",
 		"selectedMethod:" : "ct 8/20/2021 06:24",
-		"textForAnnotation:from:at:" : "pre 11/23/2020 11:57",
+		"textForAnnotation:from:at:" : "jb 11/10/2021 23:27",
 		"unstyledTextFrom:" : "lu 6/1/2021 21:39" } }

--- a/packages/Babylonian-UI.package/BPUnannotatedStyler.class/README.md
+++ b/packages/Babylonian-UI.package/BPUnannotatedStyler.class/README.md
@@ -1,0 +1,1 @@
+A BPUnannotatedStyler is styling the same way the BPStyler does with the addition of hiding the generated annotations to make the source code seem unannotated while still being able to maintain the text anchors when edited.

--- a/packages/Babylonian-UI.package/BPUnannotatedStyler.class/instance/annotationMorphFor..st
+++ b/packages/Babylonian-UI.package/BPUnannotatedStyler.class/instance/annotationMorphFor..st
@@ -1,0 +1,9 @@
+private
+annotationMorphFor: anAnnotation
+
+	
+	^ (super annotationMorphFor: anAnnotation)
+		vResizing: #rigid;
+		extent: 1@1;
+		hide;
+		yourself

--- a/packages/Babylonian-UI.package/BPUnannotatedStyler.class/instance/insertExamplesMorphFrom.into.basedOn..st
+++ b/packages/Babylonian-UI.package/BPUnannotatedStyler.class/instance/insertExamplesMorphFrom.into.basedOn..st
@@ -1,0 +1,5 @@
+private
+insertExamplesMorphFrom: parseResult into: text basedOn: annotations
+
+	"Do nothing"
+	^ text

--- a/packages/Babylonian-UI.package/BPUnannotatedStyler.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPUnannotatedStyler.class/methodProperties.json
@@ -1,0 +1,6 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"annotationMorphFor:" : "jb 11/10/2021 23:30",
+		"insertExamplesMorphFrom:into:basedOn:" : "jb 11/10/2021 23:56" } }

--- a/packages/Babylonian-UI.package/BPUnannotatedStyler.class/properties.json
+++ b/packages/Babylonian-UI.package/BPUnannotatedStyler.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "Babylonian-UI",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "jb 11/10/2021 23:54",
+	"instvars" : [
+		 ],
+	"name" : "BPUnannotatedStyler",
+	"pools" : [
+		 ],
+	"super" : "BPStyler",
+	"type" : "normal" }


### PR DESCRIPTION
Hides the Annotations in source code by shrinking and not rendering them to create the illusion of an unannotated source version. Adds a "unannotated" option to display it in the BPBrowser.
![image](https://user-images.githubusercontent.com/33000454/141208243-1607ff45-1254-4058-9150-f9dc7bba01af.png).

Solves https://github.com/hpi-swa-lab/babylonian-programming-smalltalk/issues/86
