### PR TITLE
Fixes failure in which example morphs were not deleted upon changing their paramaters

### DIFF
--- a/packages/Babylonian-UI.package/CodeHolder.extension/instance/saveMethodWithExamples.st
+++ b/packages/Babylonian-UI.package/CodeHolder.extension/instance/saveMethodWithExamples.st
@@ -1,5 +1,8 @@
 *Babylonian-UI-private
 saveMethodWithExamples
-	
-	self codeTextMorph hasUnacceptedEdits: true.
-	self codeTextMorph accept.
+
+	self codeTextMorph 
+		hasUnacceptedEdits: true;
+		updateStyleNow;
+		flag: #workaround;"BPStyler is currently not thread-safe, make sure to terminate any background styling operations before triggering the styler again in the line."
+		accept.

--- a/packages/Babylonian-UI.package/CodeHolder.extension/methodProperties.json
+++ b/packages/Babylonian-UI.package/CodeHolder.extension/methodProperties.json
@@ -22,5 +22,5 @@
 		"removeProbeFromSelection" : "pre 7/23/2019 14:48",
 		"removeReplacementFromSelection" : "pre 4/29/2020 19:07",
 		"removeSelectedAnnotationsSatisfying:" : "pre 7/26/2019 16:08",
-		"saveMethodWithExamples" : "pre 10/6/2020 11:03",
+		"saveMethodWithExamples" : "jb 12/30/2021 23:08",
 		"saveMethodWithExamplesWith:" : "pre 8/6/2019 13:57" } }


### PR DESCRIPTION
Follow up to https://github.com/hpi-swa-lab/babylonian-programming-smalltalk/pull/92 caused by https://github.com/hpi-swa-lab/babylonian-programming-smalltalk/issues/93