### PR TITLE
Mark `CompiledMethod>>methodNode` as override method

### DIFF
--- a/packages/Babylonian-Compiler.package/CompiledMethod.extension/instance/methodNode.st
+++ b/packages/Babylonian-Compiler.package/CompiledMethod.extension/instance/methodNode.st
@@ -1,4 +1,4 @@
-*Babylonian-Compiler
+*Babylonian-Compiler-decompiling-override
 methodNode
 	 
 	"Return the parse tree that represents self. If parsing fails, decompile the method."


### PR DESCRIPTION
Omitting the `-override` can bring you in serious trouble when trying to unload the package!