### PR TITLE
Feature/delete all probes for example

### DIFF
--- a/packages/Babylonian-Printbugger.package/BPLabelMorph.class/instance/removeButtonClicked.st
+++ b/packages/Babylonian-Printbugger.package/BPLabelMorph.class/instance/removeButtonClicked.st
@@ -1,4 +1,4 @@
-private - ui
+actions
 removeButtonClicked
 
 	self containingBrowser

--- a/packages/Babylonian-UI.package/BPExampleMorph.class/instance/addMenuButtonMorph.st
+++ b/packages/Babylonian-UI.package/BPExampleMorph.class/instance/addMenuButtonMorph.st
@@ -1,0 +1,10 @@
+private - ui
+addMenuButtonMorph
+
+	| menuButton |
+	menuButton := self newMenuButton.
+	menuButton 
+		actionSelector: #offerMenuContent;
+		target: self;
+		balloonText: 'open the action menu'.
+	self addMorphBack: menuButton.

--- a/packages/Babylonian-UI.package/BPExampleMorph.class/instance/deleteAllAnnotationsClicked.st
+++ b/packages/Babylonian-UI.package/BPExampleMorph.class/instance/deleteAllAnnotationsClicked.st
@@ -1,0 +1,13 @@
+actions
+deleteAllAnnotationsClicked
+
+	"Deletes all annotations for this example."
+	| browser annotations |
+	browser := BPBrowser open.
+	annotations := self example trace probes.
+	annotations addAll: self example trace assertions.
+	annotations do: [:annotationTraceValues | 
+		browser browseReference: annotationTraceValues first containedMethodReference.
+		browser removeAnnotations: {annotationTraceValues first belongingAnnotation}].
+	
+	browser currentWindow delete

--- a/packages/Babylonian-UI.package/BPExampleMorph.class/instance/menuContentsSymbolQuints.st
+++ b/packages/Babylonian-UI.package/BPExampleMorph.class/instance/menuContentsSymbolQuints.st
@@ -1,0 +1,6 @@
+content
+menuContentsSymbolQuints
+
+	"Format: action method . display text in menu . tooltip text"
+	^#(
+		(deleteAllAnnotationsClicked	'delete all annotations' 	'Delete all annotations for this example')).

--- a/packages/Babylonian-UI.package/BPExampleMorph.class/instance/newMenuButton.st
+++ b/packages/Babylonian-UI.package/BPExampleMorph.class/instance/newMenuButton.st
@@ -1,0 +1,14 @@
+private - ui
+newMenuButton
+
+	| menuButton |
+	menuButton := IconicButton new.
+	menuButton 
+		labelGraphic: (BPIcons settingsIcon scaledToSize: self iconSize * 0.7);
+		color: Color transparent;
+		borderWidth: 0;
+		extent: menuButton extent * 0.7.
+	menuButton 
+		actionSelector: #offerMenuContent;
+		target: self.
+	^ menuButton

--- a/packages/Babylonian-UI.package/BPExampleMorph.class/instance/offerMenuContent.st
+++ b/packages/Babylonian-UI.package/BPExampleMorph.class/instance/offerMenuContent.st
@@ -1,0 +1,18 @@
+what to show
+offerMenuContent
+
+	"Offer a menu governing what to show"
+	| builder menuSpec |
+	
+	builder := ToolBuilder default.
+	menuSpec := builder pluggableMenuSpec new.
+	self menuContentsSymbolQuints do: [:aQuint | 
+		| item |
+		item := menuSpec 
+			add: (aQuint second asString)
+			target: self 
+			selector: aQuint first asSymbol
+			argumentList: Array empty.
+		item help: aQuint third.
+	].
+	builder runModal: (builder open: menuSpec).

--- a/packages/Babylonian-UI.package/BPExampleMorph.class/instance/updateMorphs.st
+++ b/packages/Babylonian-UI.package/BPExampleMorph.class/instance/updateMorphs.st
@@ -11,4 +11,5 @@ updateMorphs
 		addExampleNameMorph;
 		addExampleConfigurationButtonMorph;
 		addExampleSpecificMorphs;
+		addMenuButtonMorph;
 		addDeleteButtonMorph.

--- a/packages/Babylonian-UI.package/BPExampleMorph.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPExampleMorph.class/methodProperties.json
@@ -11,6 +11,7 @@
 		"addExampleNameMorph" : "pre 2/22/2021 12:06",
 		"addExampleSpecificMorphs" : "jb 12/5/2021 02:01",
 		"addLoaderIconHolder" : "jb 12/7/2020 18:58",
+		"addMenuButtonMorph" : "lu 1/25/2022 00:15",
 		"assertResultButtonClicked" : "jb 12/30/2021 19:10",
 		"assertResultIcon" : "jb 12/30/2021 22:41",
 		"collapse" : "jb 12/6/2021 21:08",
@@ -19,6 +20,7 @@
 		"collapseInExamplesMorph" : "jb 1/7/2022 23:15",
 		"configurationButtonClicked" : "pre 5/5/2021 18:12",
 		"containedMethod" : "jb 12/6/2021 18:23",
+		"deleteAllAnnotationsClicked" : "lu 1/25/2022 00:09",
 		"ensureLoaderIcon" : "jb 12/7/2020 18:58",
 		"ensureNoLoaderIcon" : "jb 12/7/2020 18:58",
 		"example" : "pre 9/30/2020 10:34",
@@ -29,8 +31,11 @@
 		"isCollapsed" : "pre 1/12/2021 10:20",
 		"isExample" : "pre 9/30/2020 10:34",
 		"isExampleActive" : "pre 9/30/2020 10:34",
+		"menuContentsSymbolQuints" : "lu 1/24/2022 23:45",
+		"newMenuButton" : "lu 1/24/2022 23:28",
+		"offerMenuContent" : "lu 1/24/2022 23:40",
 		"removeButtonClicked" : "jb 1/10/2022 19:46",
 		"step" : "jb 12/30/2021 22:37",
 		"textEmphasis" : "pre 9/30/2020 10:35",
 		"updateAssertResultIcon" : "jb 12/30/2021 22:33",
-		"updateMorphs" : "jb 12/30/2021 18:17" } }
+		"updateMorphs" : "lu 1/24/2022 23:20" } }


### PR DESCRIPTION
`BPExampleMorph` now has a menu button that (currently only) offers the option to delete all annotations (= probes and assertions) of its example.
<img width="829" alt="openMenu" src="https://user-images.githubusercontent.com/49516192/151846159-80f2316e-262e-4e31-9b0f-9a368933407a.png">
<img width="829" alt="afterDelete" src="https://user-images.githubusercontent.com/49516192/151846169-f629fb00-f153-40f9-b724-0b8cf2ef1dae.png">

