### PR TITLE
compilerclass info added

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Metacello new
 
 ![Babylonian/S screenshot][babylonian_screenshot]
 
-## How To Ensure Tracing for Individual Methods
+## How To Ensure Tracing for Own Classes
 When using Babylonian in your own development, make sure to add 
 ```Smalltalk
 compilerClass

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Metacello new
 
 ## How To Ensure Tracing for Individual Methods
 When using Babylonian in your own development, make sure to add 
-```compilerClass
+```Smalltalk
+compilerClass
 
 	^ BPCompiler
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Metacello new
 
 ![Babylonian/S screenshot][babylonian_screenshot]
 
+## How To Ensure Tracing for Individual Methods
+When using Babylonian in your own development, make sure to add 
+```compilerClass
+
+	^ BPCompiler
+```
+on your class' side. Otherwise, the trace will disregard that class for performance reasons. 
+
+
 ## Babylonian Printbugger
 Due to their self-contained nature, traced values of multiple annotations are not entangled, meaning developers must manually reconstruct the program flow in order to know which trace values precede or succeed others in different annotations (possibly throughout different methods). To solve this problem, one can use the Printbugger. It sets probes and assertions - independent from their origin - into a chronological context. Hence, truthfully bringing printf-like tracing with live feedback to Babylonian Programming. The Printbugger additionally offers multiple features to enhance it from typical printf-traces: 
 - Start debugging from a certain point in the trace by clicking the pause button

--- a/packages/Babylonian-UI.package/BPProbeMorph.class/instance/noValuesTextFor..st
+++ b/packages/Babylonian-UI.package/BPProbeMorph.class/instance/noValuesTextFor..st
@@ -3,7 +3,10 @@ noValuesTextFor: aTrace
 	
 	| text |
 	text := 'no values' , (aTrace hasTraceCompleted 
-		ifTrue: ['']
+		ifTrue: [
+			aTrace probes 
+				ifEmpty: [' - did you adjust compilerClass of this class and re-probe?']
+				ifNotEmpty:[' - expression reachable?']]
 		ifFalse: [' yet']).
 	^ (Text fromString: text) 
 		addAttribute: (TextColor color: Color lightGray); 

--- a/packages/Babylonian-UI.package/BPProbeMorph.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPProbeMorph.class/methodProperties.json
@@ -22,7 +22,7 @@
 		"newLineMorphFor:" : "pre 5/26/2021 20:46",
 		"newScrollPane" : "pre 1/6/2021 10:50",
 		"newVisualizeButtonFor:" : "jb 10/28/2021 18:57",
-		"noValuesTextFor:" : "pre 6/7/2021 15:07",
+		"noValuesTextFor:" : "joabe 5/16/2023 20:48",
 		"relevantTracesOf:do:" : "pre 5/3/2021 10:46",
 		"setExpressionButtonClicked" : "pre 9/22/2020 10:05",
 		"setLabelButtonClicked" : "lu 5/28/2021 21:37",


### PR DESCRIPTION
Getting into development, one wonders why there are no trace values for own classes. Experienced developers know the need for setting the class' compiler. However, this info is nowhere to be found yet. This PR adds an information on the readme and hints at it when no trace values are found.