### PR TITLE
Unannotated View Available By Default

### DIFF
--- a/packages/Babylonian-UI.package/BPBrowser.class/class/initialize.st
+++ b/packages/Babylonian-UI.package/BPBrowser.class/class/initialize.st
@@ -2,7 +2,7 @@ class initialization
 initialize
 	
 	"BPBrowser initialize"
-
+	
 	"rare but correct for browsers"
 	super initialize.
 	self environment at: #TheWorldMenu ifPresent: [:menu |
@@ -10,4 +10,5 @@ initialize
 			menu unregisterOpenCommand: 'Babylonian Browser'.
 			menu registerOpenCommand: {'Babylonian Browser'. {self. #open}}]].
 	
+	ContentsSymbolQuints := self defaultContentsSymbolQuints asOrderedCollection.
 	Smalltalk addToStartUpList: self.

--- a/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
+++ b/packages/Babylonian-UI.package/BPBrowser.class/methodProperties.json
@@ -4,7 +4,7 @@
 		"automaticallyAcceptMethodOnAddingAnnotations:" : "pre 6/7/2021 14:35",
 		"compilerClass" : "pre 7/26/2019 10:07",
 		"defaultContentsSymbolQuints" : "jb 10/30/2021 17:40",
-		"initialize" : "pre 8/25/2020 10:35",
+		"initialize" : "joabe 5/30/2023 16:17",
 		"startUp" : "jb 12/3/2020 23:07" },
 	"instance" : {
 		"aboutToStyle:" : "jb 12/3/2020 23:32",

--- a/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/instance/baseline..st
+++ b/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/instance/baseline..st
@@ -32,7 +32,7 @@ baseline: spec
 				yourself.
 			spec
 				group: 'default' with: #('Babylonian-Core' 'Babylonian-UI' 'Babylonian-Printbugger');
-				group: 'tests' with: #('Babylonian-Tests' 'Babylonian-Printbugger-Tests');
+				group: 'tests' with: #('Babylonian-Tests');
 				group: 'full' with: #(tests 'Babylonian-Demo')];
 				
 		yourself

--- a/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/instance/baseline..st
+++ b/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/instance/baseline..st
@@ -32,7 +32,7 @@ baseline: spec
 				yourself.
 			spec
 				group: 'default' with: #('Babylonian-Core' 'Babylonian-UI' 'Babylonian-Printbugger');
-				group: 'tests' with: #('Babylonian-Tests');
+				group: 'tests' with: #('Babylonian-Tests' 'Babylonian-Printbugger-Tests');
 				group: 'full' with: #(tests 'Babylonian-Demo')];
 				
 		yourself

--- a/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/instance/postLoadUI.st
+++ b/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/instance/postLoadUI.st
@@ -5,3 +5,6 @@ postLoadUI
 	CharacterSet cleanUp: false.
 	
 	(Smalltalk at: #BPEmojis) initialize.
+	
+	"Ensure proper setup for e.g. default quints for unannotated view" 
+	BPBrowser initialize.

--- a/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/methodProperties.json
+++ b/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
-		"baseline:" : "joabe 5/30/2023 16:59",
+		"baseline:" : "joabe 5/30/2023 17:19",
 		"postLoadCompiler" : "pre 2/22/2021 10:51",
 		"postLoadTests" : "pre 7/7/2021 15:01",
 		"postLoadUI" : "joabe 5/30/2023 16:58" } }

--- a/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/methodProperties.json
+++ b/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
-		"baseline:" : "pre 7/7/2021 14:59",
+		"baseline:" : "joabe 5/30/2023 16:59",
 		"postLoadCompiler" : "pre 2/22/2021 10:51",
 		"postLoadTests" : "pre 7/7/2021 15:01",
-		"postLoadUI" : "pre 10/16/2020 15:28" } }
+		"postLoadUI" : "joabe 5/30/2023 16:58" } }


### PR DESCRIPTION
Although implemented, the unannotated view could not be accessed as `BPBrowser initialize` did not call `CodeHolder initialize`. That is because `Browser` overwrites `initialize`, thus not setting `ContentsSymbolQuints` of `BPBrowser`. One might argue calling `CodeHolder >> addContentsSymbolQuint: afterEntry: ` would be more suitable, but as the unannotated view should indeed be part of the `BPBrowser`'s default selections, manually setting the variable was my preferred choice.